### PR TITLE
Adds the ability of specifying a clingo version through --build-arg.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:latest
 
-ENV CLINGO_TAG_VERSION v5.2.2
+ARG tag_version
 
 RUN apt-get update && \
   apt-get install -y git build-essential cmake bison re2c && \
@@ -11,8 +11,10 @@ RUN mkdir /opt/clingo
 RUN cd /opt/clingo && \
   git init && \
   git remote add origin https://github.com/potassco/clingo.git && \
-  git fetch origin ${CLINGO_TAG_VERSION} && \
-  git pull origin ${CLINGO_TAG_VERSION} && \
+  if test -z "$tag_version" ; \
+    then git fetch origin master                && git pull origin master; \
+    else git fetch origin ${tag_version} && git pull origin ${tag_version}; \
+  fi && \
   git submodule update --init --recursive
 
 WORKDIR /opt/clingo

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ A Docker image for the Potassco [clingo](https://github.com/potassco/clingo) sof
 ### Build the solver directly from source (https://github.com/potassco/clingo)
 Check out this repo and run: `docker build -t clingo .`
 
+#### Specific versions of clingo
+Optionally, a specific version of clingo can be built. For example: `docker build --build-arg tag_version=v5.4.0 -t clingo .`
+
+The specified tag_version must match an existing tag from the [clingo github repository](https://github.com/potassco/clingo). By default, the latest version available in the repository (from the master branch) will be built.
+
 ### Run clingo from Docker
 `docker run -it --rm -v ~/docker-clingo:/tmp kdrakon/clingo:latest clingo -n 2 /tmp/examples/nonmontonic`
 
@@ -18,3 +23,4 @@ To play around with clingo and the rest of the suite of tools, just run:
 `docker run -it --rm kdrakon/clingo:latest bash`
 
 Binaries for clingo, gringo (grounder), and clasp (solver) are available on the PATH so that they can be executed anywhere on the command line.
+


### PR DESCRIPTION
The user must provide a valid tag (from the clingo repository) via '--build-arg=tag_name'. If not provided, the Dockerfile will pull the master branch and build clingo from that.
On branch specify_version
Changes to be committed:
	modified:   Dockerfile
		Defines the Dockerfile argument and builds the proper version based on its value.
	modified:   README.md
		Defines a new section 'Specific versions of clingo' explaining the use of the new argument.